### PR TITLE
Open panel keybind

### DIFF
--- a/keymaps/goto-mathematica.cson
+++ b/keymaps/goto-mathematica.cson
@@ -1,3 +1,5 @@
 'atom-text-editor':
   'f10': 'goto-mathematica:go-to-cursor'
+  'shift-f10': 'goto-mathematica:go-to-cursor-pane'
   'f9': 'goto-mathematica:go-to-symbol'
+  'shift-f9': 'goto-mathematica:go-to-symbol-pane'

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -19,6 +19,7 @@ module.exports =
           marker = editor.markBufferRange(matchInfo.range)
           position = marker.getStartScreenPosition()
           editor.setCursorScreenPosition(position)
+          editor.scrollToScreenPosition(position,{center:true})
           
   testPaths: (files) ->
     reducer = (foundPath, path) =>

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -5,13 +5,13 @@ _ = require 'underscore-plus'
 module.exports =
   regexp: ""
 
-  gotoWord: (word) ->
+  gotoWord: (word, openPane) ->
     @regexp = new RegExp("\\b"+word+"\\[.*\\]\\s*:=")
     directories = atom.project.getDirectories()
     path = @testPaths directories
     if _.isString(path)
       options = {}
-      if atom.config.get('goto-mathematica.splitPane')
+      if openPane 
         options.pending = true
         options.split = 'right'
       atom.workspace.open(path,options).then (editor) =>

--- a/lib/views/symbol-palette-view.coffee
+++ b/lib/views/symbol-palette-view.coffee
@@ -8,6 +8,8 @@ class SymbolPaletteView extends View
     @div class: 'symbol-palette', =>
       @div ''
       @subview 'symbolPaletteView', new TextEditorView(mini: true)
+  
+  @openInPane: false
 
   initialize: ->
     atom.commands.add @element,
@@ -19,7 +21,8 @@ class SymbolPaletteView extends View
         @cancel()
         event.stopPropagation()
 
-  show: ->
+  show: (openPane) ->
+    @openInPane = openPane
     @panel ?=atom.workspace.addModalPanel(item: this)
     @symbolPaletteView.focus()
 
@@ -37,5 +40,5 @@ class SymbolPaletteView extends View
   cancel: -> @hide()
 
   confirm: ->
-    Search.gotoWord(@symbolPaletteView.getText())
+    Search.gotoWord(@symbolPaletteView.getText(), @openInPane)
     @hide()

--- a/main.coffee
+++ b/main.coffee
@@ -4,27 +4,27 @@ Search = require './lib/search'
 
 module.exports =
   subscriptions: null
-  config:
-    splitPane:
-      type: 'boolean'
-      default: true
   regexp: ""
 
   activate: ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-text-editor',
-      'goto-mathematica:go-to-cursor': => @gotoCursor()
+      'goto-mathematica:go-to-cursor': => @gotoCursor(false)
     @subscriptions.add atom.commands.add 'atom-text-editor',
-      'goto-mathematica:go-to-symbol': => @gotoView()
+      'goto-mathematica:go-to-cursor-pane': => @gotoCursor(true)
+    @subscriptions.add atom.commands.add 'atom-text-editor',
+      'goto-mathematica:go-to-symbol': => @gotoView(false)
+    @subscriptions.add atom.commands.add 'atom-text-editor',
+      'goto-mathematica:go-to-symbol-pane': => @gotoView(true)
 
   deactivate: ->
     @subscriptions.dispose()
 
-  gotoView: ->
+  gotoView: (openPane) ->
     @paletteView = new SymbolPaletteView()
-    @paletteView.show()
+    @paletteView.show(openPane)
 
-  gotoCursor: ->
+  gotoCursor: (openPane) ->
     editor = atom.workspace.getActivePaneItem()
     word = editor.getWordUnderCursor()
-    Search.gotoWord(word)
+    Search.gotoWord(word, openPane)


### PR DESCRIPTION
Adds two new keybindings to open the found symbol in a new pending pane on the right.
Removes the configuration value for always opening the file in the existing panel or in a split pane as both instances are useful in different circumstances.
